### PR TITLE
Rb/get config rework

### DIFF
--- a/serviceregistry/src/main/java/eu/arrowhead/serviceregistry/ServiceRegistryConstants.java
+++ b/serviceregistry/src/main/java/eu/arrowhead/serviceregistry/ServiceRegistryConstants.java
@@ -1,7 +1,5 @@
 package eu.arrowhead.serviceregistry;
 
-import java.util.List;
-
 import eu.arrowhead.common.jpa.ArrowheadEntity;
 
 public final class ServiceRegistryConstants {
@@ -71,30 +69,6 @@ public final class ServiceRegistryConstants {
 	public static final String $SERVICE_DISCOVERY_DIRECT_ACCESS_WD = "${" + SERVICE_DISCOVERY_DIRECT_ACCESS + ":" + ServiceRegistryDefaults.SERVICE_DISCOVERY_DIRECT_ACCESS_DEFAULT + "}";
 	public static final String SERVICE_DISCOVERY_INTERFACE_POLICY = "service.discovery.interface.policy";
 	public static final String $SERVICE_DISCOVERY_INTERFACE_POLICY_WD = "${" + SERVICE_DISCOVERY_INTERFACE_POLICY + ":" + ServiceRegistryDefaults.SERVICE_DISCOVERY_INTERFACE_POLICY_DEFAULT + "}";
-
-	// Forbidden keys (for config service)
-
-	public static final List<String> FORBIDDEN_KEYS = List.of(
-			// database related
-			"spring.datasource.url",
-			"spring.datasource.username",
-			"spring.datasource.password",
-			"spring.datasource.driver-class-name",
-			"spring.jpa.hibernate.ddl-auto",
-			"spring.jpa.show-sql",
-
-			// cert related
-			"authenticator.secret.key",
-			"server.ssl.key-store-type",
-			"server.ssl.key-store",
-			"server.ssl.key-store-password",
-			"server.ssl.key-alias",
-			"server.ssl.key-password",
-			"server.ssl.client-auth",
-			"server.ssl.trust-store-type",
-			"server.ssl.trust-store",
-			"server.ssl.trust-store-password",
-			"disable.hostname.verifier");
 
 	// Property size related
 

--- a/serviceregistry/src/main/java/eu/arrowhead/serviceregistry/ServiceRegistryConstants.java
+++ b/serviceregistry/src/main/java/eu/arrowhead/serviceregistry/ServiceRegistryConstants.java
@@ -64,12 +64,13 @@ public final class ServiceRegistryConstants {
 	// Configuration related
 
 	public static final String DISCOVERY_VERBOSE = "discovery.verbose";
-	public static final String $DISCOVERY_VERBOSE_WD = "${" + DISCOVERY_VERBOSE + ":false}";
+	public static final String $DISCOVERY_VERBOSE_WD = "${" + DISCOVERY_VERBOSE + ":" + ServiceRegistryDefaults.DISCOVERY_VERBOSE_DEFAULT + "}";
 	public static final String SERVICE_DISCOVERY_POLICY = "service.discovery.policy";
-	public static final String $SERVICE_DISCOVERY_POLICY_WD = "${" + SERVICE_DISCOVERY_POLICY + ":restricted}";
+	public static final String $SERVICE_DISCOVERY_POLICY_WD = "${" + SERVICE_DISCOVERY_POLICY + ":" + ServiceRegistryDefaults.SERVICE_DISCOVERY_POLICY_DEFAULT + "}";
 	public static final String SERVICE_DISCOVERY_DIRECT_ACCESS = "service.discovery.direct.access";
+	public static final String $SERVICE_DISCOVERY_DIRECT_ACCESS_WD = "${" + SERVICE_DISCOVERY_DIRECT_ACCESS + ":" + ServiceRegistryDefaults.SERVICE_DISCOVERY_DIRECT_ACCESS_DEFAULT + "}";
 	public static final String SERVICE_DISCOVERY_INTERFACE_POLICY = "service.discovery.interface.policy";
-	public static final String $SERVICE_DISCOVERY_INTERFACE_POLICY_WD = "${" + SERVICE_DISCOVERY_INTERFACE_POLICY + ":restricted}";
+	public static final String $SERVICE_DISCOVERY_INTERFACE_POLICY_WD = "${" + SERVICE_DISCOVERY_INTERFACE_POLICY + ":" + ServiceRegistryDefaults.SERVICE_DISCOVERY_INTERFACE_POLICY_DEFAULT + "}";
 
 	// Forbidden keys (for config service)
 

--- a/serviceregistry/src/main/java/eu/arrowhead/serviceregistry/ServiceRegistryDefaults.java
+++ b/serviceregistry/src/main/java/eu/arrowhead/serviceregistry/ServiceRegistryDefaults.java
@@ -1,0 +1,25 @@
+package eu.arrowhead.serviceregistry;
+
+import eu.arrowhead.common.Defaults;
+import eu.arrowhead.serviceregistry.service.ServiceDiscoveryInterfacePolicy;
+import eu.arrowhead.serviceregistry.service.ServiceDiscoveryPolicy;
+
+public final class ServiceRegistryDefaults extends Defaults {
+
+	//=================================================================================================
+	// members
+
+	public static final String DISCOVERY_VERBOSE_DEFAULT = "false";
+	public static final String SERVICE_DISCOVERY_POLICY_DEFAULT = ServiceDiscoveryPolicy.RESTRICTED_VALUE;
+	public static final String SERVICE_DISCOVERY_DIRECT_ACCESS_DEFAULT = "\"\"";
+	public static final String SERVICE_DISCOVERY_INTERFACE_POLICY_DEFAULT = ServiceDiscoveryInterfacePolicy.RESTRICTED_VALUE;
+
+	//=================================================================================================
+	// assistant methods
+
+	//-------------------------------------------------------------------------------------------------
+	private ServiceRegistryDefaults() {
+		throw new UnsupportedOperationException();
+	}
+
+}

--- a/serviceregistry/src/main/java/eu/arrowhead/serviceregistry/ServiceRegistrySystemInfo.java
+++ b/serviceregistry/src/main/java/eu/arrowhead/serviceregistry/ServiceRegistrySystemInfo.java
@@ -143,7 +143,23 @@ public class ServiceRegistrySystemInfo extends SystemInfo {
 	@Override
 	protected PublicConfigurationKeysAndDefaults getPublicConfigurationKeysAndDefaults() {
 		return new PublicConfigurationKeysAndDefaults(
-				List.of(), // TODO: need keys here
+				Set.of(Constants.SERVER_ADDRESS,
+					   Constants.SERVER_PORT,
+					   Constants.MQTT_API_ENABLED,
+					   Constants.DOMAIN_NAME,
+					   Constants.AUTHENTICATION_POLICY,
+					   Constants.ENABLE_MANAGEMENT_FILTER,
+					   Constants.MANAGEMENT_POLICY,
+					   Constants.ENABLE_BLACKLIST_FILTER,
+					   Constants.FORCE_BLACKLIST_FILTER,
+					   Constants.ALLOW_SELF_ADDRESSING,
+					   Constants.ALLOW_NON_ROUTABLE_ADDRESSING,
+					   Constants.MAX_PAGE_SIZE,
+					   Constants.SERVICE_ADDRESS_ALIAS,
+					   ServiceRegistryConstants.SERVICE_DISCOVERY_POLICY,
+					   ServiceRegistryConstants.DISCOVERY_VERBOSE,
+					   ServiceRegistryConstants.SERVICE_DISCOVERY_INTERFACE_POLICY
+						), 
 				ServiceRegistryDefaults.class);
 	}
 

--- a/serviceregistry/src/main/java/eu/arrowhead/serviceregistry/ServiceRegistrySystemInfo.java
+++ b/serviceregistry/src/main/java/eu/arrowhead/serviceregistry/ServiceRegistrySystemInfo.java
@@ -30,7 +30,7 @@ public class ServiceRegistrySystemInfo extends SystemInfo {
 	@Value(ServiceRegistryConstants.$DISCOVERY_VERBOSE_WD)
 	private boolean discoveryVerbose;
 
-	@Value(ServiceRegistryConstants.SERVICE_DISCOVERY_DIRECT_ACCESS)
+	@Value(ServiceRegistryConstants.$SERVICE_DISCOVERY_DIRECT_ACCESS_WD)
 	private List<String> serviceDiscoveryDirectAccess;
 
 	@Value(ServiceRegistryConstants.$SERVICE_DISCOVERY_POLICY_WD)
@@ -138,6 +138,14 @@ public class ServiceRegistrySystemInfo extends SystemInfo {
 
 	//=================================================================================================
 	// assistant methods
+
+	//-------------------------------------------------------------------------------------------------
+	@Override
+	protected PublicConfigurationKeysAndDefaults getPublicConfigurationKeysAndDefaults() {
+		return new PublicConfigurationKeysAndDefaults(
+				List.of(), // TODO: need keys here
+				ServiceRegistryDefaults.class);
+	}
 
 	//-------------------------------------------------------------------------------------------------
 	// HTTP Interfaces

--- a/serviceregistry/src/main/java/eu/arrowhead/serviceregistry/ServiceRegistrySystemInfo.java
+++ b/serviceregistry/src/main/java/eu/arrowhead/serviceregistry/ServiceRegistrySystemInfo.java
@@ -144,22 +144,21 @@ public class ServiceRegistrySystemInfo extends SystemInfo {
 	protected PublicConfigurationKeysAndDefaults getPublicConfigurationKeysAndDefaults() {
 		return new PublicConfigurationKeysAndDefaults(
 				Set.of(Constants.SERVER_ADDRESS,
-					   Constants.SERVER_PORT,
-					   Constants.MQTT_API_ENABLED,
-					   Constants.DOMAIN_NAME,
-					   Constants.AUTHENTICATION_POLICY,
-					   Constants.ENABLE_MANAGEMENT_FILTER,
-					   Constants.MANAGEMENT_POLICY,
-					   Constants.ENABLE_BLACKLIST_FILTER,
-					   Constants.FORCE_BLACKLIST_FILTER,
-					   Constants.ALLOW_SELF_ADDRESSING,
-					   Constants.ALLOW_NON_ROUTABLE_ADDRESSING,
-					   Constants.MAX_PAGE_SIZE,
-					   Constants.SERVICE_ADDRESS_ALIAS,
-					   ServiceRegistryConstants.SERVICE_DISCOVERY_POLICY,
-					   ServiceRegistryConstants.DISCOVERY_VERBOSE,
-					   ServiceRegistryConstants.SERVICE_DISCOVERY_INTERFACE_POLICY
-						), 
+						Constants.SERVER_PORT,
+						Constants.MQTT_API_ENABLED,
+						Constants.DOMAIN_NAME,
+						Constants.AUTHENTICATION_POLICY,
+						Constants.ENABLE_MANAGEMENT_FILTER,
+						Constants.MANAGEMENT_POLICY,
+						Constants.ENABLE_BLACKLIST_FILTER,
+						Constants.FORCE_BLACKLIST_FILTER,
+						Constants.ALLOW_SELF_ADDRESSING,
+						Constants.ALLOW_NON_ROUTABLE_ADDRESSING,
+						Constants.MAX_PAGE_SIZE,
+						Constants.SERVICE_ADDRESS_ALIAS,
+						ServiceRegistryConstants.SERVICE_DISCOVERY_POLICY,
+						ServiceRegistryConstants.DISCOVERY_VERBOSE,
+						ServiceRegistryConstants.SERVICE_DISCOVERY_INTERFACE_POLICY),
 				ServiceRegistryDefaults.class);
 	}
 

--- a/serviceregistry/src/main/java/eu/arrowhead/serviceregistry/api/http/GeneralManagementAPI.java
+++ b/serviceregistry/src/main/java/eu/arrowhead/serviceregistry/api/http/GeneralManagementAPI.java
@@ -90,6 +90,6 @@ public class GeneralManagementAPI {
 		logger.debug("getConfig started ...");
 
 		final String origin = HttpMethod.GET.name() + " " + ServiceRegistryConstants.HTTP_API_GENERAL_MANAGEMENT_PATH + Constants.HTTP_API_OP_GET_CONFIG_PATH;
-		return configService.getConfig(keys, ServiceRegistryConstants.FORBIDDEN_KEYS, origin);
+		return configService.getConfig(keys, origin);
 	}
 }

--- a/serviceregistry/src/main/java/eu/arrowhead/serviceregistry/api/mqtt/GeneralManagementMqttHandler.java
+++ b/serviceregistry/src/main/java/eu/arrowhead/serviceregistry/api/mqtt/GeneralManagementMqttHandler.java
@@ -87,6 +87,6 @@ public class GeneralManagementMqttHandler extends MqttTopicHandler {
 	//-------------------------------------------------------------------------------------------------
 	private KeyValuesDTO getConfig(final List<String> dto) {
 		logger.debug("ManagementMqttHandler.getConfig started");
-		return configService.getConfig(dto, ServiceRegistryConstants.FORBIDDEN_KEYS, topic());
+		return configService.getConfig(dto, topic());
 	}
 }

--- a/serviceregistry/src/main/java/eu/arrowhead/serviceregistry/service/ServiceDiscoveryInterfacePolicy.java
+++ b/serviceregistry/src/main/java/eu/arrowhead/serviceregistry/service/ServiceDiscoveryInterfacePolicy.java
@@ -1,5 +1,9 @@
 package eu.arrowhead.serviceregistry.service;
 
 public enum ServiceDiscoveryInterfacePolicy {
-	OPEN, EXTENDABLE, RESTRICTED
+	OPEN, EXTENDABLE, RESTRICTED;
+
+	// members
+
+	public static final String RESTRICTED_VALUE = "RESTRICTED"; // right side must be a constant expression
 }

--- a/serviceregistry/src/main/java/eu/arrowhead/serviceregistry/service/ServiceDiscoveryPolicy.java
+++ b/serviceregistry/src/main/java/eu/arrowhead/serviceregistry/service/ServiceDiscoveryPolicy.java
@@ -1,5 +1,10 @@
 package eu.arrowhead.serviceregistry.service;
 
 public enum ServiceDiscoveryPolicy {
-	OPEN, RESTRICTED
+	OPEN, RESTRICTED;
+
+	//=================================================================================================
+	// members
+
+	public static final String RESTRICTED_VALUE = "RESTRICTED"; // right side must be a constant expression
 }

--- a/serviceregistry/src/main/java/eu/arrowhead/serviceregistry/service/model/ServiceLookupFilterModel.java
+++ b/serviceregistry/src/main/java/eu/arrowhead/serviceregistry/service/model/ServiceLookupFilterModel.java
@@ -37,34 +37,34 @@ public class ServiceLookupFilterModel {
 		Assert.notNull(dto, "ServiceInstanceLookupRequestDTO is null");
 
 		if (!Utilities.isEmpty(dto.instanceIds())) {
-		    instanceIds.addAll(dto.instanceIds());
+			instanceIds.addAll(dto.instanceIds());
 		}
-		
+
 		if (!Utilities.isEmpty(dto.providerNames())) {
 			providerNames.addAll(dto.providerNames());
 		}
-		
+
 		if (!Utilities.isEmpty(dto.serviceDefinitionNames())) {
 			serviceDefinitionNames.addAll(dto.serviceDefinitionNames());
 		}
-		
+
 		if (!Utilities.isEmpty(dto.versions())) {
 			versions.addAll(dto.versions());
 		}
-		
+
 		alivesAt = Utilities.parseUTCStringToZonedDateTime(dto.alivesAt());
 		if (!Utilities.isEmpty(dto.metadataRequirementsList())) {
 			metadataRequirementsList.addAll(dto.metadataRequirementsList());
 		}
-		
+
 		if (!Utilities.isEmpty(dto.interfaceTemplateNames())) {
 			interfaceTemplateNames.addAll(dto.interfaceTemplateNames());
 		}
-		
+
 		if (!Utilities.isEmpty(dto.interfacePropertyRequirementsList())) {
 			interfacePropertyRequirementsList.addAll(dto.interfacePropertyRequirementsList());
 		}
-		
+
 		if (!Utilities.isEmpty(dto.policies())) {
 			policies.addAll(dto.policies().stream().map(p -> ServiceInterfacePolicy.valueOf(p)).collect(Collectors.toSet()));
 		}

--- a/serviceregistry/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/serviceregistry/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -88,5 +88,15 @@
     "name": "mqtt.client.password",
     "type": "java.lang.String",
     "description": "A description for 'mqtt.client.password'"
+  },
+  {
+    "name": "force.blacklist.filter",
+    "type": "java.lang.Boolean",
+    "description": "A description for 'force.blacklist.filter'"
+  },
+  {
+    "name": "disable.hostname.verifier",
+    "type": "java.lang.Boolean",
+    "description": "A description for 'disable.hostname.verifier'"
   }
 ]}


### PR DESCRIPTION
Implementation of issue #58

After merging this to development, we have to adjust existing systems to the changes:

@Katinka666 Blacklist
@rbocsi Authentication
@borditamas Service Orchestration (also checking SR, because there can be new properties)

Adjusting involves:

- Creating a system-specific *Defaults class for the system-specific defaults which is a subclass of the Defaults class;
- Modifying the system-specific *Constants class using the defaults in EL expression, also deleting the FORBIDDEN_KEYS list;
- Implementing a new method in system-specific *SystemInfo class by providing a set of public config keys and the class object of the above-mentioned *Defaults class;
- The signature of getConfig service is changed, so have some easy modification in the API classes (both HTTP and MQTT);

See example in the Service Registry