### PR TITLE
Renaming tokenType input to tokenVariant & Orch lock mgmt bugfix

### DIFF
--- a/consumer-authorization/src/main/java/eu/arrowhead/authorization/service/AuthorizationTokenManagementService.java
+++ b/consumer-authorization/src/main/java/eu/arrowhead/authorization/service/AuthorizationTokenManagementService.java
@@ -122,7 +122,7 @@ public class AuthorizationTokenManagementService {
 					requester,
 					request.consumer(),
 					request.consumerCloud(),
-					ServiceInterfacePolicy.valueOf(request.tokenType()),
+					ServiceInterfacePolicy.valueOf(request.tokenVariant()),
 					request.provider(),
 					AuthorizationTargetType.valueOf(request.targetType()),
 					request.target(),

--- a/consumer-authorization/src/main/java/eu/arrowhead/authorization/service/AuthorizationTokenService.java
+++ b/consumer-authorization/src/main/java/eu/arrowhead/authorization/service/AuthorizationTokenService.java
@@ -92,7 +92,7 @@ public class AuthorizationTokenService {
 		}
 
 		// Generate token
-		final ServiceInterfacePolicy tokenType = ServiceInterfacePolicy.valueOf(normalizedDTO.tokenType());
+		final ServiceInterfacePolicy tokenType = ServiceInterfacePolicy.valueOf(normalizedDTO.tokenVariant());
 		final TokenModel tokenResult = tokenEngine.produce(
 				normalizedRequester,
 				normalizedRequester,
@@ -104,7 +104,7 @@ public class AuthorizationTokenService {
 				origin);
 
 		// Encrypt token if required
-		final AuthorizationTokenType authorizationTokenType = AuthorizationTokenType.fromServiceInterfacePolicy(ServiceInterfacePolicy.valueOf(normalizedDTO.tokenType()));
+		final AuthorizationTokenType authorizationTokenType = AuthorizationTokenType.fromServiceInterfacePolicy(ServiceInterfacePolicy.valueOf(normalizedDTO.tokenVariant()));
 		if (authorizationTokenType == AuthorizationTokenType.SELF_CONTAINED_TOKEN) {
 			tokenEngine.encryptTokenIfNeeded(tokenResult, origin);
 		}

--- a/consumer-authorization/src/main/java/eu/arrowhead/authorization/service/normalization/AuthorizationTokenNormalizer.java
+++ b/consumer-authorization/src/main/java/eu/arrowhead/authorization/service/normalization/AuthorizationTokenNormalizer.java
@@ -75,7 +75,7 @@ public class AuthorizationTokenNormalizer {
 				: eventTypeNameNormalizer.normalize(dto.target());
 
 		return new AuthorizationTokenGenerationRequestDTO(
-				dto.tokenType().toUpperCase().trim(),
+				dto.tokenVariant().toUpperCase().trim(),
 				systemNameNormalizer.normalize(dto.provider()),
 				normalizedTargetType,
 				normalizedTarget,
@@ -108,7 +108,7 @@ public class AuthorizationTokenNormalizer {
 									: eventTypeNameNormalizer.normalize(item.target());
 
 							return new AuthorizationTokenGenerationMgmtRequestDTO(
-									item.tokenType().trim().toUpperCase(),
+									item.tokenVariant().trim().toUpperCase(),
 									normalizedTargetType,
 									Utilities.isEmpty(item.consumerCloud()) ? DTODefaults.DEFAULT_CLOUD : cloudIdentifierNormalizer.normalize(item.consumerCloud()),
 									systemNameNormalizer.normalize(item.consumer()),

--- a/consumer-authorization/src/main/java/eu/arrowhead/authorization/service/validation/AuthorizationTokenManagementValidation.java
+++ b/consumer-authorization/src/main/java/eu/arrowhead/authorization/service/validation/AuthorizationTokenManagementValidation.java
@@ -111,8 +111,8 @@ public class AuthorizationTokenManagementValidation {
 		final AuthorizationTokenGenerationMgmtListRequestDTO normalized = tokenNormalizer.normalizeAuthorizationTokenGenerationMgmtListRequestDTO(dto);
 
 		for (final AuthorizationTokenGenerationMgmtRequestDTO request : normalized.list()) {
-			if (!request.tokenType().endsWith(Constants.AUTHORIZATION_TOKEN_TYPE_SUFFIX)) {
-				throw new InvalidParameterException("Invalid token type: " + request.tokenType(), origin);
+			if (!request.tokenVariant().endsWith(Constants.AUTHORIZATION_TOKEN_VARIANT_SUFFIX)) {
+				throw new InvalidParameterException("Invalid token variant: " + request.tokenVariant(), origin);
 			}
 
 			try {
@@ -235,11 +235,11 @@ public class AuthorizationTokenManagementValidation {
 		}
 
 		for (final AuthorizationTokenGenerationMgmtRequestDTO request : dto.list()) {
-			if (Utilities.isEmpty(request.tokenType())) {
-				throw new InvalidParameterException("Token type is missing", origin);
+			if (Utilities.isEmpty(request.tokenVariant())) {
+				throw new InvalidParameterException("Token variant is missing", origin);
 			}
 
-			final String tokenTypeName = request.tokenType().trim().toUpperCase();
+			final String tokenTypeName = request.tokenVariant().trim().toUpperCase();
 			if (!Utilities.isEnumValue(tokenTypeName, ServiceInterfacePolicy.class)) {
 				throw new InvalidParameterException("Token type is invalid: " + tokenTypeName, origin);
 			}

--- a/consumer-authorization/src/main/java/eu/arrowhead/authorization/service/validation/AuthorizationTokenManagementValidation.java
+++ b/consumer-authorization/src/main/java/eu/arrowhead/authorization/service/validation/AuthorizationTokenManagementValidation.java
@@ -239,9 +239,9 @@ public class AuthorizationTokenManagementValidation {
 				throw new InvalidParameterException("Token variant is missing", origin);
 			}
 
-			final String tokenTypeName = request.tokenVariant().trim().toUpperCase();
-			if (!Utilities.isEnumValue(tokenTypeName, ServiceInterfacePolicy.class)) {
-				throw new InvalidParameterException("Token type is invalid: " + tokenTypeName, origin);
+			final String tokenVariant = request.tokenVariant().trim().toUpperCase();
+			if (!Utilities.isEnumValue(tokenVariant, ServiceInterfacePolicy.class)) {
+				throw new InvalidParameterException("Token variant is invalid: " + tokenVariant, origin);
 			}
 
 			if (!Utilities.isEmpty(request.targetType())) {

--- a/consumer-authorization/src/main/java/eu/arrowhead/authorization/service/validation/AuthorizationTokenValidation.java
+++ b/consumer-authorization/src/main/java/eu/arrowhead/authorization/service/validation/AuthorizationTokenValidation.java
@@ -154,9 +154,9 @@ public class AuthorizationTokenValidation {
 			throw new InvalidParameterException("Token variant is missing", origin);
 		}
 
-		final String tokenTypeName = dto.tokenVariant().trim().toUpperCase();
-		if (!Utilities.isEnumValue(tokenTypeName, ServiceInterfacePolicy.class)) {
-			throw new InvalidParameterException("Token type is invalid: " + tokenTypeName, origin);
+		final String tokenVariant = dto.tokenVariant().trim().toUpperCase();
+		if (!Utilities.isEnumValue(tokenVariant, ServiceInterfacePolicy.class)) {
+			throw new InvalidParameterException("Token variant is invalid: " + tokenVariant, origin);
 		}
 
 		if (Utilities.isEmpty(dto.provider())) {

--- a/consumer-authorization/src/main/java/eu/arrowhead/authorization/service/validation/AuthorizationTokenValidation.java
+++ b/consumer-authorization/src/main/java/eu/arrowhead/authorization/service/validation/AuthorizationTokenValidation.java
@@ -81,8 +81,8 @@ public class AuthorizationTokenValidation {
 		final AuthorizationTokenGenerationRequestDTO normalized = normalizer.normalizeAuthorizationTokenGenerationRequestDTO(dto);
 
 		try {
-			if (!normalized.tokenType().endsWith(Constants.AUTHORIZATION_TOKEN_TYPE_SUFFIX)) {
-				throw new InvalidParameterException("Token type is invalid", origin);
+			if (!normalized.tokenVariant().endsWith(Constants.AUTHORIZATION_TOKEN_VARIANT_SUFFIX)) {
+				throw new InvalidParameterException("Token variant is invalid", origin);
 			}
 
 			systemNameValidator.validateSystemName(normalized.provider());
@@ -150,11 +150,11 @@ public class AuthorizationTokenValidation {
 			throw new InvalidParameterException("Request payload is missing", origin);
 		}
 
-		if (Utilities.isEmpty(dto.tokenType())) {
-			throw new InvalidParameterException("Token type is missing", origin);
+		if (Utilities.isEmpty(dto.tokenVariant())) {
+			throw new InvalidParameterException("Token variant is missing", origin);
 		}
 
-		final String tokenTypeName = dto.tokenType().trim().toUpperCase();
+		final String tokenTypeName = dto.tokenVariant().trim().toUpperCase();
 		if (!Utilities.isEnumValue(tokenTypeName, ServiceInterfacePolicy.class)) {
 			throw new InvalidParameterException("Token type is invalid: " + tokenTypeName, origin);
 		}

--- a/serviceorchestration-dynamic/src/main/java/eu/arrowhead/serviceorchestration/DynamicServiceOrchestrationConstants.java
+++ b/serviceorchestration-dynamic/src/main/java/eu/arrowhead/serviceorchestration/DynamicServiceOrchestrationConstants.java
@@ -74,6 +74,7 @@ public final class DynamicServiceOrchestrationConstants {
 	public static final String HTTP_PATH_PARAM_OWNER = "{owner}";
 	public static final String HTTP_API_OP_REMOVE_LOCK_PATH = "/remove/" + HTTP_PATH_PARAM_OWNER;
 	public static final String PARAM_NAME_TRIGGER = "trigger";
+	public static final String PARAM_NAME_OWNER = "owner";
 
 	public static final String ORCH_WARN_AUTO_MATCHMAKING = "autoMatchmaking";
 	public static final String ORCH_WARN_QOS_NOT_ENABLED = "qosNotEnabled";

--- a/serviceorchestration-dynamic/src/main/java/eu/arrowhead/serviceorchestration/api/mqtt/OrchestrationLockManagementMqttHandler.java
+++ b/serviceorchestration-dynamic/src/main/java/eu/arrowhead/serviceorchestration/api/mqtt/OrchestrationLockManagementMqttHandler.java
@@ -66,9 +66,10 @@ public class OrchestrationLockManagementMqttHandler extends MqttTopicHandler {
 			break;
 
 		case Constants.SERVICE_OP_ORCHESTRATION_REMOVE:
+			final String owner = request.getParams().get(DynamicServiceOrchestrationConstants.PARAM_NAME_OWNER);
 			final List<String> removeReqDTO = readPayload(request.getPayload(), new TypeReference<List<String>>() {
 			});
-			remove(request.getRequester(), removeReqDTO);
+			remove(owner, removeReqDTO);
 			break;
 
 		default:

--- a/serviceorchestration-dynamic/src/main/java/eu/arrowhead/serviceorchestration/service/utils/LocalServiceOrchestration.java
+++ b/serviceorchestration-dynamic/src/main/java/eu/arrowhead/serviceorchestration/service/utils/LocalServiceOrchestration.java
@@ -731,7 +731,7 @@ public class LocalServiceOrchestration {
 			}
 
 			candidate.getMatchingInterfaces().forEach(interf -> {
-				if (interf.policy().endsWith(Constants.AUTHORIZATION_TOKEN_TYPE_SUFFIX)) {
+				if (interf.policy().endsWith(Constants.AUTHORIZATION_TOKEN_VARIANT_SUFFIX)) {
 					scopeList.forEach(scope -> {
 						requestPayloadEntries.add(new AuthorizationTokenGenerationMgmtRequestDTO(
 								interf.policy(),


### PR DESCRIPTION
Renaming tokenType input to tokenVariant where we use it as the exact token identifier, and not as the token technology group. Unfortunately I used the same field name for both...